### PR TITLE
Add angularity definition (lambda_beta_kappa) as defined in literature

### DIFF
--- a/cpptools/src/fjext/fjtools.cxx
+++ b/cpptools/src/fjext/fjtools.cxx
@@ -17,6 +17,24 @@ namespace FJTools
 		return _ang;
 	}
 
+	// Angularity definition as it is given in arXiv:1408.3122
+	double lambda_beta_kappa(const fastjet::PseudoJet &j, double beta, double kappa, double scaleR0)
+	{
+		double _l = 0;  // init lambda
+		const std::vector<fastjet::PseudoJet> &_cs = j.constituents();
+
+		// If there are no constituents (empty jet), return an underflow value
+		if (_cs.size() < 1) { return -1; }
+
+		for (unsigned int i = 0; i < _cs.size(); i++)
+		{
+			const fastjet::PseudoJet &_p = _cs[i];
+			_l += std::pow(_p.perp(), kappa) * std::pow(_p.delta_R(j) / scaleR0, beta);
+		}
+		_l /= std::pow(j.perp(), kappa);
+		return _l;
+	}
+
 	std::vector<fastjet::PseudoJet> vectorize_pt_eta_phi(double *pt, int npt, double *eta, int neta, double *phi, int nphi, int user_index_offset)
 	{
 		std::vector<fastjet::PseudoJet> v;

--- a/cpptools/src/fjext/fjtools.hh
+++ b/cpptools/src/fjext/fjtools.hh
@@ -7,6 +7,7 @@
 namespace FJTools
 {
 	double angularity(const fastjet::PseudoJet &j, double alpha, double scaleR0);
+	double lambda_beta_kappa(const fastjet::PseudoJet &j, double beta, double kappa, double scaleR0);
 
 	std::vector<fastjet::PseudoJet> vectorize_pt_eta_phi(double *pt, int npt, double *eta, int neta, double *phi, int nphi, int user_index_offset = 0);
 	std::vector<fastjet::PseudoJet> vectorize_pt_eta_phi_m(double *pt, int npt, double *eta, int neta, double *phi, int nphi, double *m, int nm, int user_index_offset = 0);


### PR DESCRIPTION
Adding additional definition of the angularity function as defined in some papers, for example
https://arxiv.org/abs/1408.3122
https://arxiv.org/abs/1807.06854

This definition also adds a check that returns -1 if the number of constituents is 0. This matches the functionality for other fastjet functions [e.g., .z(), .Delta()] which returns an underflow value if the jet does not pass the SoftDrop condition.