### PR TITLE
Overloaded lambda_beta_kappa

### DIFF
--- a/cpptools/src/fjext/fjtools.cxx
+++ b/cpptools/src/fjext/fjtools.cxx
@@ -34,6 +34,24 @@ namespace FJTools
 		return _l;
 	}
 
+	// Overloaded definition allowing for a custom jet pT
+	// For example: Use this definition for groomed jets (passing in ungroomed pT)
+	double lambda_beta_kappa(const fastjet::PseudoJet &j, double jet_pT,
+							 double beta, double kappa, double scaleR0)
+	{
+		// If there are no constituents (empty jet), return an underflow value
+		if (!j.has_constituents()) { return -1; }
+
+		double _l = 0;  // init lambda
+		const std::vector<fastjet::PseudoJet> &_cs = j.constituents();
+		for (unsigned int i = 0; i < _cs.size(); i++)
+		{
+			const fastjet::PseudoJet &_p = _cs[i];
+			_l += std::pow(_p.perp(), kappa) * std::pow(_p.delta_R(j) / scaleR0, beta);
+		}
+		_l /= std::pow(jet_pT, kappa);
+		return _l;
+	}
 	std::vector<fastjet::PseudoJet> vectorize_pt_eta_phi(double *pt, int npt, double *eta, int neta, double *phi, int nphi, int user_index_offset)
 	{
 		std::vector<fastjet::PseudoJet> v;

--- a/cpptools/src/fjext/fjtools.hh
+++ b/cpptools/src/fjext/fjtools.hh
@@ -8,6 +8,8 @@ namespace FJTools
 {
 	double angularity(const fastjet::PseudoJet &j, double alpha, double scaleR0);
 	double lambda_beta_kappa(const fastjet::PseudoJet &j, double beta, double kappa, double scaleR0);
+	double lambda_beta_kappa(const fastjet::PseudoJet &j, double jet_pT,
+							 double beta, double kappa, double scaleR0);
 
 	std::vector<fastjet::PseudoJet> vectorize_pt_eta_phi(double *pt, int npt, double *eta, int neta, double *phi, int nphi, int user_index_offset = 0);
 	std::vector<fastjet::PseudoJet> vectorize_pt_eta_phi_m(double *pt, int npt, double *eta, int neta, double *phi, int nphi, double *m, int nm, int user_index_offset = 0);


### PR DESCRIPTION
... for specifying the jet pT to be used separately. This function should be used for SoftDrop (with ungroomed jet pT). 