### PR TITLE
Update angularities for JEWEL thermal subtraction

### DIFF
--- a/cpptools/src/fjext/fjtools.cxx
+++ b/cpptools/src/fjext/fjtools.cxx
@@ -18,7 +18,8 @@ namespace FJTools
 	}
 
 	// Angularity definition as it is given in arXiv:1408.3122
-	double lambda_beta_kappa(const fastjet::PseudoJet &j, double beta, double kappa, double scaleR0)
+	double lambda_beta_kappa(const fastjet::PseudoJet &j, double beta, double kappa,
+		double scaleR0, bool check_user_index/*=false*/)
 	{
 		// If there are no constituents (empty jet), return an underflow value
 		if (!j.has_constituents()) { return -1; }
@@ -29,7 +30,7 @@ namespace FJTools
 		{
 			const fastjet::PseudoJet &_p = _cs[i];
 			// If particle is a thermal, subtract instead of adding
-			if (_p.user_index() < 0) {
+			if (check_user_index && _p.user_index() < 0) {
 				_l -= std::pow(_p.perp(), kappa) *
 					std::pow(_p.delta_R(j) / scaleR0, beta);
 			} else {
@@ -43,7 +44,7 @@ namespace FJTools
 
 	// Use this overloaded definition for groomed jets
 	double lambda_beta_kappa(const fastjet::PseudoJet &j, const fastjet::PseudoJet &j_groomed,
-                             double beta, double kappa, double scaleR0)
+		double beta, double kappa, double scaleR0, bool check_user_index/*=false*/)
 	{
 		// If there are no constituents (empty jet), return an underflow value
 		if (!j.has_constituents() || !j_groomed.has_constituents()) { return -1; }
@@ -54,7 +55,7 @@ namespace FJTools
 		{
 			const fastjet::PseudoJet &_p = _cs[i];
 			// If particle is a thermal, subtract instead of adding
-			if (_p.user_index() < 0) {
+			if (check_user_index && _p.user_index() < 0) {
 				_l -= std::pow(_p.perp(), kappa) *
 					std::pow(_p.delta_R(j) / scaleR0, beta);
 			} else {

--- a/cpptools/src/fjext/fjtools.cxx
+++ b/cpptools/src/fjext/fjtools.cxx
@@ -28,7 +28,14 @@ namespace FJTools
 		for (unsigned int i = 0; i < _cs.size(); i++)
 		{
 			const fastjet::PseudoJet &_p = _cs[i];
-			_l += std::pow(_p.perp(), kappa) * std::pow(_p.delta_R(j) / scaleR0, beta);
+                        // If particle is a thermal, subtract instead of adding
+                        if (_p.user_info() < 0) {
+				_l -= std::pow(_p.perp(), kappa) *
+					std::pow(_p.delta_R(j) / scaleR0, beta);
+                        } else {
+				_l += std::pow(_p.perp(), kappa) *
+					std::pow(_p.delta_R(j) / scaleR0, beta);
+                        }
 		}
 		_l /= std::pow(j.perp(), kappa);
 		return _l;
@@ -46,7 +53,14 @@ namespace FJTools
 		for (unsigned int i = 0; i < _cs.size(); i++)
 		{
 			const fastjet::PseudoJet &_p = _cs[i];
-			_l += std::pow(_p.perp(), kappa) * std::pow(_p.delta_R(j) / scaleR0, beta);
+                        // If particle is a thermal, subtract instead of adding
+                        if (_p.user_info() < 0) {
+				_l -= std::pow(_p.perp(), kappa) *
+					std::pow(_p.delta_R(j) / scaleR0, beta);
+			} else {
+				_l += std::pow(_p.perp(), kappa) *
+					std::pow(_p.delta_R(j) / scaleR0, beta);
+			}
 		}
 		_l /= std::pow(j.perp(), kappa);
 		return _l;
@@ -55,7 +69,7 @@ namespace FJTools
 	std::vector<fastjet::PseudoJet> vectorize_pt_eta_phi(double *pt, int npt, double *eta, int neta, double *phi, int nphi, int user_index_offset)
 	{
 		std::vector<fastjet::PseudoJet> v;
-		if (npt != neta || npt != nphi) 
+		if (npt != neta || npt != nphi)
 		{
 			std::cerr << "[error] vectorize_pt_eta_phi : incompatible array sizes" << std::endl;
 			return v;

--- a/cpptools/src/fjext/fjtools.cxx
+++ b/cpptools/src/fjext/fjtools.cxx
@@ -28,14 +28,14 @@ namespace FJTools
 		for (unsigned int i = 0; i < _cs.size(); i++)
 		{
 			const fastjet::PseudoJet &_p = _cs[i];
-                        // If particle is a thermal, subtract instead of adding
-                        if (_p.user_index() < 0) {
+			// If particle is a thermal, subtract instead of adding
+			if (_p.user_index() < 0) {
 				_l -= std::pow(_p.perp(), kappa) *
 					std::pow(_p.delta_R(j) / scaleR0, beta);
-                        } else {
+			} else {
 				_l += std::pow(_p.perp(), kappa) *
 					std::pow(_p.delta_R(j) / scaleR0, beta);
-                        }
+			}
 		}
 		_l /= std::pow(j.perp(), kappa);
 		return _l;
@@ -53,8 +53,8 @@ namespace FJTools
 		for (unsigned int i = 0; i < _cs.size(); i++)
 		{
 			const fastjet::PseudoJet &_p = _cs[i];
-                        // If particle is a thermal, subtract instead of adding
-                        if (_p.user_index() < 0) {
+			// If particle is a thermal, subtract instead of adding
+			if (_p.user_index() < 0) {
 				_l -= std::pow(_p.perp(), kappa) *
 					std::pow(_p.delta_R(j) / scaleR0, beta);
 			} else {

--- a/cpptools/src/fjext/fjtools.cxx
+++ b/cpptools/src/fjext/fjtools.cxx
@@ -29,7 +29,7 @@ namespace FJTools
 		{
 			const fastjet::PseudoJet &_p = _cs[i];
                         // If particle is a thermal, subtract instead of adding
-                        if (_p.user_info() < 0) {
+                        if (_p.user_index() < 0) {
 				_l -= std::pow(_p.perp(), kappa) *
 					std::pow(_p.delta_R(j) / scaleR0, beta);
                         } else {
@@ -54,7 +54,7 @@ namespace FJTools
 		{
 			const fastjet::PseudoJet &_p = _cs[i];
                         // If particle is a thermal, subtract instead of adding
-                        if (_p.user_info() < 0) {
+                        if (_p.user_index() < 0) {
 				_l -= std::pow(_p.perp(), kappa) *
 					std::pow(_p.delta_R(j) / scaleR0, beta);
 			} else {

--- a/cpptools/src/fjext/fjtools.hh
+++ b/cpptools/src/fjext/fjtools.hh
@@ -8,9 +8,9 @@
 namespace FJTools
 {
 	double angularity(const fastjet::PseudoJet &j, double alpha, double scaleR0);
-	double lambda_beta_kappa(const fastjet::PseudoJet &j, double beta, double kappa, double scaleR0);
+	double lambda_beta_kappa(const fastjet::PseudoJet &j, double beta, double kappa, double scaleR0, bool check_user_index = false);
 	double lambda_beta_kappa(const fastjet::PseudoJet &j, const fastjet::PseudoJet &j_groomed,
-							 double beta, double kappa, double scaleR0);
+		double beta, double kappa, double scaleR0, bool check_user_index = false);
 
 	std::vector<fastjet::PseudoJet> vectorize_pt_eta_phi(double *pt, int npt, double *eta, int neta, double *phi, int nphi, int user_index_offset = 0);
 	std::vector<fastjet::PseudoJet> vectorize_pt_eta_phi_m(double *pt, int npt, double *eta, int neta, double *phi, int nphi, double *m, int nm, int user_index_offset = 0);


### PR DESCRIPTION
(sorry for the second PR today)
Update the definitions of the angularities so that `constituent.user_info() < 0` (which is true for JEWEL thermal particles) are subtracted from the overall angularity, whereas "normal" particles are still added. 