### PR TITLE
fjcontrib update / PYTHIA with non-default particle mass

### DIFF
--- a/cpptools/src/fjcontrib/CMakeLists.txt
+++ b/cpptools/src/fjcontrib/CMakeLists.txt
@@ -1,5 +1,5 @@
 message( STATUS "CMAKE_CURRENT_SOURCE_DIR: ${CMAKE_CURRENT_SOURCE_DIR}")
-set(fjcontrib_version "1.051")
+set(fjcontrib_version "1.053")
 execute_process ( COMMAND
                  ${CMAKE_CURRENT_SOURCE_DIR}/buildtools/get_fj_contrib.sh
                  ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/buildtools

--- a/cpptools/src/fjcontrib/buildtools/get_fj_contrib.sh
+++ b/cpptools/src/fjcontrib/buildtools/get_fj_contrib.sh
@@ -6,7 +6,7 @@ if [ ! -z ${wdir} ]; then
 	[ ! -d ${wdir} ] && mkdir -p ${wdir}
 fi
 
-fjcontrib_version=1.051
+fjcontrib_version=1.053
 [ ! -z ${3} ] && fjcontrib_version=${3}
 
 if [ -d ${srcdir} ]; then
@@ -19,6 +19,7 @@ if [ -d ${srcdir} ]; then
 			if [ ! -d ${srcdir}/fjcontrib-${fjcontrib_version}/RecursiveTools ]; then
 				cd ${srcdir}
 				tar zxvf ${wdir}/fjcontrib-${fjcontrib_version}.tar.gz fjcontrib-${fjcontrib_version}/RecursiveTools
+                rm fjcontrib-${fjcontrib_version}/*/.[!.]*  # Remove unnecessary dotfiles
 				rm fjcontrib-${fjcontrib_version}/RecursiveTools/example_*.cc
 				patch fjcontrib-${fjcontrib_version}/RecursiveTools/RecursiveSymmetryCutBase.hh -i ${srcdir}/patches/RecursiveSymmetryCutBase.patch
 			fi
@@ -30,6 +31,7 @@ if [ -d ${srcdir} ]; then
 			if [ ! -d ${srcdir}/fjcontrib-${fjcontrib_version}/LundPlane ]; then
 				cd ${srcdir}
 				tar zxvf ${wdir}/fjcontrib-${fjcontrib_version}.tar.gz fjcontrib-${fjcontrib_version}/LundPlane
+                rm fjcontrib-${fjcontrib_version}/*/.[!.]*  # Remove unnecessary dotfiles
 				rm fjcontrib-${fjcontrib_version}/LundPlane/example_*.cc
 				patch fjcontrib-${fjcontrib_version}/LundPlane/SecondaryLund.hh -i ${srcdir}/patches/SecondaryLund.patch
 				patch fjcontrib-${fjcontrib_version}/LundPlane/LundGenerator.hh -i ${srcdir}/patches/LundGenerator.patch
@@ -44,6 +46,7 @@ if [ -d ${srcdir} ]; then
 			if [ ! -d ${srcdir}/fjcontrib-${fjcontrib_version}/ConstituentSubtractor ]; then
 				cd ${srcdir}
 				tar zxvf ${wdir}/fjcontrib-${fjcontrib_version}.tar.gz fjcontrib-${fjcontrib_version}/ConstituentSubtractor
+                rm fjcontrib-${fjcontrib_version}/*/.[!.]*  # Remove unnecessary dotfiles
 				rm fjcontrib-${fjcontrib_version}/ConstituentSubtractor/example_*.cc
 			fi
 
@@ -51,6 +54,7 @@ if [ -d ${srcdir} ]; then
 			if [ ! -d ${srcdir}/fjcontrib-${fjcontrib_version}/Nsubjettiness ]; then
 				cd ${srcdir}
 				tar zxvf ${wdir}/fjcontrib-${fjcontrib_version}.tar.gz fjcontrib-${fjcontrib_version}/Nsubjettiness
+                rm fjcontrib-${fjcontrib_version}/*/.[!.]*  # Remove unnecessary dotfiles
 				rm fjcontrib-${fjcontrib_version}/Nsubjettiness/example_*.cc
 				patch fjcontrib-${fjcontrib_version}/Nsubjettiness/MeasureDefinition.hh -i ${srcdir}/patches/MeasureDefinition.patch
 				patch fjcontrib-${fjcontrib_version}/Nsubjettiness/AxesDefinition.hh -i ${srcdir}/patches/AxesDefinition.patch

--- a/cpptools/src/fjcontrib/buildtools/get_fj_contrib.sh
+++ b/cpptools/src/fjcontrib/buildtools/get_fj_contrib.sh
@@ -18,8 +18,7 @@ if [ -d ${srcdir} ]; then
 			# RecursiveTools
 			if [ ! -d ${srcdir}/fjcontrib-${fjcontrib_version}/RecursiveTools ]; then
 				cd ${srcdir}
-				tar zxvf ${wdir}/fjcontrib-${fjcontrib_version}.tar.gz fjcontrib-${fjcontrib_version}/RecursiveTools
-                rm fjcontrib-${fjcontrib_version}/*/.[!.]*  # Remove unnecessary dotfiles
+				tar zxvf ${wdir}/fjcontrib-${fjcontrib_version}.tar.gz fjcontrib-${fjcontrib_version}/RecursiveTools --warning=no-unknown-keyword
 				rm fjcontrib-${fjcontrib_version}/RecursiveTools/example_*.cc
 				patch fjcontrib-${fjcontrib_version}/RecursiveTools/RecursiveSymmetryCutBase.hh -i ${srcdir}/patches/RecursiveSymmetryCutBase.patch
 			fi
@@ -30,8 +29,7 @@ if [ -d ${srcdir} ]; then
 			# LundPlane
 			if [ ! -d ${srcdir}/fjcontrib-${fjcontrib_version}/LundPlane ]; then
 				cd ${srcdir}
-				tar zxvf ${wdir}/fjcontrib-${fjcontrib_version}.tar.gz fjcontrib-${fjcontrib_version}/LundPlane
-                rm fjcontrib-${fjcontrib_version}/*/.[!.]*  # Remove unnecessary dotfiles
+				tar zxvf ${wdir}/fjcontrib-${fjcontrib_version}.tar.gz fjcontrib-${fjcontrib_version}/LundPlane --warning=no-unknown-keyword
 				rm fjcontrib-${fjcontrib_version}/LundPlane/example_*.cc
 				patch fjcontrib-${fjcontrib_version}/LundPlane/SecondaryLund.hh -i ${srcdir}/patches/SecondaryLund.patch
 				patch fjcontrib-${fjcontrib_version}/LundPlane/LundGenerator.hh -i ${srcdir}/patches/LundGenerator.patch
@@ -45,20 +43,21 @@ if [ -d ${srcdir} ]; then
 			# ConstituentSubtractor
 			if [ ! -d ${srcdir}/fjcontrib-${fjcontrib_version}/ConstituentSubtractor ]; then
 				cd ${srcdir}
-				tar zxvf ${wdir}/fjcontrib-${fjcontrib_version}.tar.gz fjcontrib-${fjcontrib_version}/ConstituentSubtractor
-                rm fjcontrib-${fjcontrib_version}/*/.[!.]*  # Remove unnecessary dotfiles
+				tar zxvf ${wdir}/fjcontrib-${fjcontrib_version}.tar.gz fjcontrib-${fjcontrib_version}/ConstituentSubtractor --warning=no-unknown-keyword
 				rm fjcontrib-${fjcontrib_version}/ConstituentSubtractor/example_*.cc
 			fi
 
 			# Nsubjettiness
 			if [ ! -d ${srcdir}/fjcontrib-${fjcontrib_version}/Nsubjettiness ]; then
 				cd ${srcdir}
-				tar zxvf ${wdir}/fjcontrib-${fjcontrib_version}.tar.gz fjcontrib-${fjcontrib_version}/Nsubjettiness
-                rm fjcontrib-${fjcontrib_version}/*/.[!.]*  # Remove unnecessary dotfiles
+				tar zxvf ${wdir}/fjcontrib-${fjcontrib_version}.tar.gz fjcontrib-${fjcontrib_version}/Nsubjettiness --warning=no-unknown-keyword
 				rm fjcontrib-${fjcontrib_version}/Nsubjettiness/example_*.cc
 				patch fjcontrib-${fjcontrib_version}/Nsubjettiness/MeasureDefinition.hh -i ${srcdir}/patches/MeasureDefinition.patch
 				patch fjcontrib-${fjcontrib_version}/Nsubjettiness/AxesDefinition.hh -i ${srcdir}/patches/AxesDefinition.patch
 			fi
+
+            rm fjcontrib-${fjcontrib_version}/.[!.]* fjcontrib-${fjcontrib_version}/*/.[!.]*  # Remove unnecessary dotfiles
+
 		fi
 	fi
 fi

--- a/cpptools/src/fjcontrib/buildtools/get_fj_contrib.sh
+++ b/cpptools/src/fjcontrib/buildtools/get_fj_contrib.sh
@@ -56,7 +56,7 @@ if [ -d ${srcdir} ]; then
 				patch fjcontrib-${fjcontrib_version}/Nsubjettiness/AxesDefinition.hh -i ${srcdir}/patches/AxesDefinition.patch
 			fi
 
-            rm fjcontrib-${fjcontrib_version}/.[!.]* fjcontrib-${fjcontrib_version}/*/.[!.]*  # Remove unnecessary dotfiles
+			rm fjcontrib-${fjcontrib_version}/.[!.]* fjcontrib-${fjcontrib_version}/*/.[!.]*  # Remove unnecessary dotfiles
 
 		fi
 	fi

--- a/cpptools/src/pythiafjext/pyfjtools.cxx
+++ b/cpptools/src/pythiafjext/pyfjtools.cxx
@@ -31,11 +31,12 @@ namespace pythiafjtools{
 		return v;
 	}
 
-	std::vector<fastjet::PseudoJet> vectorize_select(const Pythia8::Pythia &pythia, 
-													 int *selection, 
+	std::vector<fastjet::PseudoJet> vectorize_select(const Pythia8::Pythia &pythia,
+													 int *selection,
 													 int nsel,
-													 int user_index_offset,
-													 bool add_particle_info)
+													 int user_index_offset/* = 0*/,
+													 bool add_particle_info/* = false*/,
+                                                     float particle_mass/* = -1*/)
 	{
 		std::vector<fastjet::PseudoJet> v;
 		std::bitset<kMaxSetting> mask(0); // no particle accepted
@@ -99,15 +100,21 @@ namespace pythiafjtools{
 			// 	std::cout << "[+] ";
 			// else
 			// 	std::cout << "[-] ";
-			// std::cout 
+			// std::cout
 			// 		<< ip << " "
 			// 		<< mask << " !-" << negmask << " " << pmask << " " << " " << "(mask & pmask) " << (mask & pmask) << " "
 			// 		<< "isFinal = " << pythia.event[ip].isFinal() << " "
-			// 		<< pythia.event[ip].name() 
+			// 		<< pythia.event[ip].name()
 			// 		<< std::endl;
 			if (accept)
 			{
-				fastjet::PseudoJet psj(pythia.event[ip].px(), pythia.event[ip].py(), pythia.event[ip].pz(), pythia.event[ip].e());
+                double particle_e = 0;
+                if (particle_mass < 0) {  // default case, use true particle mass
+                    particle_e = pythia.event[ip].e();
+                } else {                  // use E^2 = p^2 + m^2
+                    particle_e = std::pow(std::pow(pythia.event[ip].px(), 2) + std::pow(pythia.event[ip].py(), 2) + std::pow(pythia.event[ip].pz(), 2) + std::pow(particle_mass, 2), 0.5);
+                }
+				fastjet::PseudoJet psj(pythia.event[ip].px(), pythia.event[ip].py(), pythia.event[ip].pz(), particle_e);
 				psj.set_user_index(ip + user_index_offset);
 				if (add_particle_info)
 				{
@@ -116,7 +123,7 @@ namespace pythiafjtools{
 				}
 				v.push_back(psj);
 			}
-		}		
+		}
 		return v;
 	}
 

--- a/cpptools/src/pythiafjext/pyfjtools.hh
+++ b/cpptools/src/pythiafjext/pyfjtools.hh
@@ -29,10 +29,11 @@ namespace pythiafjtools{
 		kMaxSetting
 	};
 
-	std::vector<fastjet::PseudoJet> vectorize_select(	const Pythia8::Pythia &p, 
-														int *selection, int nsel, 
+	std::vector<fastjet::PseudoJet> vectorize_select(	const Pythia8::Pythia &p,
+														int *selection, int nsel,
 														int user_index_offset = 0,
-														bool add_particle_info = false);
+														bool add_particle_info = false,
+                                                        float particle_mass = -1);
 
 	// implemented in fjtools
 	// double angularity(const fastjet::PseudoJet &j, double alpha, double scaleR0 = 1.);

--- a/cpptools/src/pythiafjext/pythiafjext.i
+++ b/cpptools/src/pythiafjext/pythiafjext.i
@@ -20,3 +20,4 @@
 %apply (int* IN_ARRAY1, int DIM1) {(int* selection, int nsel)};
 %include "pyfjtools.hh"
 %clear (int* selection, int nsel);
+%template(FJPSJVec) std::vector<fastjet::PseudoJet>;


### PR DESCRIPTION
Add parameter to function which creates PseudoJet vector in order to allow non-default mass assumptions (e.g., assuming charged pi meson mass). The parameter is optional and turned off by default, so should not affect any existing code.